### PR TITLE
ci: publish releases to the Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,17 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aliases: major minor


### PR DESCRIPTION
Adds a fan-in `tap` job (needs `build`) to the release workflow that calls SierraSoftworks/actions-tap to update the tailon Homebrew formula whenever a release is published. The job generates major and minor versioned aliases so consumers can pin to a version range.