### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This project provides a web-based application manager that runs on your [Tailsca
 
 ## Installation
 
+### Homebrew
+
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/tailon
+```
+
+### Go
+
 ```bash
 go install github.com/sierrasoftworks/tailon@latest
 ```


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/tailon

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
